### PR TITLE
Add verbosity to error's related to input path being a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ npm install -g epub2json
 
 ## Usage
 
-Convert .epub files from src path to .json file in output path.
+Convert all *.epub files contained in a directory path, to *.json files in output path. (overwrites existing inputName.json files)
 
 ```
 $ epub2json convert -i </path/to/epubs> -o </path/to/output>

--- a/index.js
+++ b/index.js
@@ -93,7 +93,12 @@ const validPath = (testPath, mode = fs.R_OK | fs.X_OK) => {
   let ok = fs.existsSync(testPath);
   if (ok) {
     const lstat = fs.lstatSync(testPath);
-    ok = lstat.isDirectory();
+    const isDirectory = lstat.isDirectory();
+    ok = isDirectory
+    if(!isDirectory){
+      error(chalk.red('Input path must be a directory containing all the *.epub files to be converted'))
+      process.exit(1);
+    }
   }
 
   if (ok) {
@@ -185,7 +190,7 @@ commander
   .command('convert')
   .description('Convert epub files to text files.')
   .option('-i, --input-path <inputPath>', 'the path to the epub files')
-  .option('-o, --output-path <outputPath>', 'the path to output the json files')
+  .option('-o, --output-path <outputPath>', 'the path to output the json files. (overwrites existing <inputFilename>.json files)')
   .on('--help', help)
   .action(convertAction);
 


### PR DESCRIPTION
Address issue #1 

This PR:
- Add a check for inputPath being a file inside the validPath function  
- Update the readme to match the script behavoir